### PR TITLE
Test connectivity.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,7 @@ hs_err_pid*
 target
 .gradle
 build
+
+# integration test parameters
+src/it/resources/integration-test.properties
+

--- a/pom.xml
+++ b/pom.xml
@@ -53,22 +53,38 @@
                     </execution>
                 </executions>
             </plugin>
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.12</version>
+                <version>2.22.2</version>
                 <configuration>
-                    <systemProperties>
-                        <property>
-                            <name>loggerPath</name>
-                            <value>conf/log4j.properties</value>
-                        </property>
-                    </systemProperties>
                     <argLine>-Xms512m -Xmx1500m</argLine>
-                    <parallel>methods</parallel>
-                    <forkMode>pertest</forkMode>
+                    <forkCount>1</forkCount>
+                    <reuseForks>false</reuseForks>
+                    <excludes>
+                        <exclude>com.fortify.ssc.restclient.api.*Test</exclude>
+                    </excludes>
                 </configuration>
             </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>2.22.2</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <argLine>-Xms512m -Xmx1500m</argLine>
+                </configuration>
+            </plugin>
+
             <plugin>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <executions>
@@ -82,6 +98,12 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>3.1.0</version>
             </plugin>
 
             <!-- attach test jar -->
@@ -127,8 +149,8 @@
                         </goals>
                         <configuration>
                             <sources>
-                                <source>
-                                src/test/java</source>
+                                <source>src/test/java</source>
+                                <source>src/it/java</source>
                             </sources>
                         </configuration>
                     </execution>
@@ -161,6 +183,16 @@
                 </executions>
             </plugin>
         </plugins>
+
+        <testResources>
+            <testResource>
+                <directory>src/it/resources</directory>
+                <includes>
+                    <include>**/*.properties</include>
+                    <include>**/*.xml</include>
+                </includes>
+            </testResource>
+        </testResources>
     </build>
 
     <profiles>
@@ -225,6 +257,21 @@
             <version>${junit-version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <version>1.14</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <version>${log4j-version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>${log4j-version}</version>
+        </dependency>
     </dependencies>
     <properties>
         <java.version>1.7</java.version>
@@ -237,6 +284,7 @@
             <threetenbp-version>1.3.5</threetenbp-version>
         <maven-plugin-version>1.0.0</maven-plugin-version>
         <junit-version>4.12</junit-version>
+        <log4j-version>2.12.1</log4j-version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/src/it/java/ListProjectsIT.java
+++ b/src/it/java/ListProjectsIT.java
@@ -1,0 +1,123 @@
+import com.fortify.ssc.restclient.*;
+import com.fortify.ssc.restclient.auth.*;
+import com.fortify.ssc.restclient.model.*;
+import com.fortify.ssc.restclient.api.ProjectControllerApi;
+import com.fortify.ssc.restclient.api.ProjectVersionOfProjectControllerApi;
+import org.apache.commons.codec.binary.Base64;
+
+import org.junit.Test;
+import org.junit.Before;
+import static org.junit.Assert.*;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.StringWriter;
+import java.io.PrintWriter;
+import java.util.Properties;
+
+public class ListProjectsIT {
+    private static Logger LOGGER = LogManager.getLogger(ListProjectsIT.class.getName());
+
+    private Properties props;
+
+    private ApiClient defaultClient;
+    private ProjectControllerApi apiInstance;
+
+    public void initFromProperties(Properties props) throws java.io.UnsupportedEncodingException {
+        this.props = props;
+        defaultClient = Configuration.getDefaultApiClient();
+        String apiToken = props.getProperty("it.fortifyApiToken");
+        if (apiToken == null || apiToken.trim().length() == 0) {
+            throw new RuntimeException("Missing it.fortifyApiToken");
+        }
+        String apiBase = props.getProperty("it.fortifyApiBase");
+        if (apiBase == null || apiBase.trim().length() == 0) {
+            throw new RuntimeException("Missing it.fortifyApiBase");
+        }
+        defaultClient.setBasePath(apiBase);
+        // Configure API key authorization: FortifyToken
+        ApiKeyAuth fortifyToken = (ApiKeyAuth) defaultClient.getAuthentication("FortifyToken");
+        fortifyToken.setApiKey(Base64.encodeBase64String(apiToken.getBytes("UTF-8")));
+        fortifyToken.setApiKeyPrefix("FortifyToken");
+    }
+
+    @Before
+    public void init() throws java.io.IOException, java.io.UnsupportedEncodingException {
+        Properties props = new Properties();
+        try (java.io.InputStream stream = this.getClass().getResourceAsStream("/integration-test.properties")) {
+            if (stream == null) {
+                props = System.getProperties();
+            } else {
+                props.load(stream);
+            }
+        }
+        initFromProperties(props);
+    }
+
+    @Test
+    public void testList() throws ApiException {
+        String projectName = props.getProperty("it.fortifyProjectName");
+        if (projectName == null || projectName.trim().length() == 0) {
+            throw new RuntimeException("Missing it.fortifyProjectName");
+        }
+        String fields = null; // "id,name,description,createdBy,creationDate,issueTemplateId,id";
+
+        Integer start = null;
+        Integer limit = null;
+        String q = "name:" + projectName;
+        Boolean fulltextsearch = null;
+        String orderby = null;
+
+        LOGGER.info("Connecting to " + defaultClient.getBasePath() + " and reading a project " + projectName + "...");
+        ProjectControllerApi projectController = new ProjectControllerApi();
+        ApiResultListProject projectsResult = null;
+        try {
+            projectsResult = projectController.listProject(fields, start, limit, q, fulltextsearch, orderby);
+            LOGGER.info(projectsResult);
+
+            assertEquals(1L, projectsResult.getCount().longValue());
+            assertEquals(projectName, ((Project)projectsResult.getData().get(0)).getName());
+        } catch (ApiException e) {
+            LOGGER.error("HTTP response code " + e.getCode());
+            if (e.getCode() == 401) {
+                LOGGER.error("Expected a fresh CIToken in it.fortifyApiToken");
+            } else {
+                StringWriter sw = new StringWriter();
+                e.printStackTrace(new PrintWriter(sw));
+                LOGGER.warn(sw.toString());
+            }
+            throw e;
+        }
+
+        Long projectId = ((Project)projectsResult.getData().get(0)).getId();
+        q = null;
+        Boolean includeInactive = null;
+        Boolean myAssignedIssues = null;
+        LOGGER.info("Reading project " + projectId.longValue());
+        ProjectVersionOfProjectControllerApi versionsOfProjectController = new ProjectVersionOfProjectControllerApi();
+        try {
+            ApiResultListProjectVersion versionsResult = versionsOfProjectController.listProjectVersionOfProject(projectId,
+                    fields, start, limit, q, fulltextsearch, orderby, includeInactive, myAssignedIssues);
+            LOGGER.info(versionsResult);
+        } catch (ApiException e) {
+            String codeMessage = "HTTP response code " + e.getCode();
+            if (e.getCode() == 401) {
+                LOGGER.error(codeMessage + ": Expected a fresh CIToken in it.fortifyApiToken");
+            } else {
+                LOGGER.error(codeMessage);
+                StringWriter sw = new StringWriter();
+                e.printStackTrace(new PrintWriter(sw));
+                LOGGER.warn(sw.toString());
+            }
+            throw e;
+        }
+    }
+
+    public static void main(String[] args) throws java.io.IOException, java.io.UnsupportedEncodingException, ApiException {
+        ListProjectsIT ts = new ListProjectsIT();
+        ts.init();
+        ts.testList();
+    }
+}
+

--- a/src/it/resources/integration-test-sample.properties
+++ b/src/it/resources/integration-test-sample.properties
@@ -1,0 +1,4 @@
+it.fortifyApiBase=https://fortify.example.com/ssc/api/v1
+it.fortifyApiToken=XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+# it.fortifyProjectVersionId=8004
+it.fortifyProjectName=WebGoat

--- a/src/it/resources/log4j2-test.xml
+++ b/src/it/resources/log4j2-test.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="error">
+    <Appenders>
+        <Console name="STDOUT" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Logger name="com.fortify" level="trace" additivity="false">
+            <AppenderRef ref="STDOUT"/>
+        </Logger>
+        <Root level="trace">
+            <AppenderRef ref="STDOUT"/>
+        </Root>
+    </Loggers>
+</Configuration>
+


### PR DESCRIPTION
Exclude auto-generated tests as they do nothing.

Separate an integration test from the unit tests.  This allows using
"mvn verify" and a parameter file

    src/it/resources/integration-test.properties

Allow running a single test directly with java,

    java -cp target/ssc-restapi-client-2.0.jar:target/lib/*:target/test-classes \
        -Djavax.net.debug=all ListProjectsIT

Highlight authentication failures.

Fixes #5.